### PR TITLE
Support multiple address entries per port in Logical_Switch_Port

### DIFF
--- a/result.go
+++ b/result.go
@@ -53,12 +53,17 @@ func (r *Row) GetColumnValue(column string, columns map[string]string) (interfac
 			return sliceDataValue.(string), "string", nil
 		case "set":
 			for _, x := range sliceDataValue.([]interface{}) {
-				k := reflect.ValueOf(x).Index(0).Interface().(string)
-				if k == "uuid" {
-					v := reflect.ValueOf(x).Index(1).Interface().(string)
-					sliceData = append(sliceData, v)
-				} else {
-					return sliceData, "", fmt.Errorf("Column %s contains %s, but []%s is not supported: %v", column, dataType, k, data)
+				switch reflect.TypeOf(x).Kind().String() {
+				case "slice":
+					k := reflect.ValueOf(x).Index(0).Interface().(string)
+					if k == "uuid" {
+						v := reflect.ValueOf(x).Index(1).Interface().(string)
+						sliceData = append(sliceData, v)
+					} else {
+						return sliceData, "", fmt.Errorf("Column %s contains %s, but []%s is not supported: %v", column, dataType, k, data)
+					}
+				case "string":
+					sliceData = append(sliceData, reflect.ValueOf(x).Interface().(string))
 				}
 			}
 			if len(sliceData) > 0 {


### PR DESCRIPTION
According to the OVN northbound reference, one logical port may have more than one address in Logical_Switch_Port table. 

https://man7.org/linux/man-pages/man5/ovn-nb.5.html#Logical_Switch_Port_TABLE

This pull request makes it possible to parse all address entries, including IPv4, IPv6, and keyword entries, such as "unknown" or "router". 

Before this change, this library would crash if it encounters a multiple address entry for a port in Northbound OVSDB:

```
Aug 19 12:05:47 xx prometheus-ovn-exporter[61679]: panic: interface conversion: interface {} is uint8, not string
Aug 19 12:05:47 xx prometheus-ovn-exporter[61679]: goroutine 36 [running]:
Aug 19 12:05:47 xx prometheus-ovn-exporter[61679]: github.com/greenpau/ovsdb.(*Row).GetColumnValue(0xc00026ab00, 0x9ceb0f, 0x9, 0xc0002ae930, 0x937480, 0xc00072ecc0, 0xc0001ee5b8, 0x11, 0x0, 0x0)
Aug 19 12:05:47 xx prometheus-ovn-exporter[61679]:         /go/pkg/mod/github.com/greenpau/ovsdb@v0.0.0-20181114004433-3582b85e8968/result.go:56 +0x21e5
Aug 19 12:05:47 xx prometheus-ovn-exporter[61679]: github.com/greenpau/ovsdb.(*OvnClient).GetLogicalSwitchPorts(0xc00030a000, 0x31, 0xc00026b780, 0x1, 0x1, 0x2)
Aug 19 12:05:47 xx prometheus-ovn-exporter[61679]:         /go/pkg/mod/github.com/greenpau/ovsdb@v0.0.0-20181114004433-3582b85e8968/ovn_logical_switch_port.go:85 +0x45d
```