### PR TITLE
Adjust the limit for system IDs

### DIFF
--- a/system.go
+++ b/system.go
@@ -79,8 +79,12 @@ func getSystemID(filepath string) (string, error) {
 	if err := scanner.Err(); err != nil {
 		return systemID, err
 	}
-	if len(systemID) != 36 {
-		return systemID, fmt.Errorf("system-id is not 32 characters in length, but %d", len(systemID))
+	// vswitch.ovsschema does not limit system IDs to a particular length and a common
+	// ID to use is UUID (36 bytes). However, some tools use FQDNs for system-ids which
+	// are limited to 253 octets per RFC1035. Hence the current limit checked by the
+	// exporter is 253 bytes to avoid arbitrary length for system IDs and to have a sane limit.
+	if len(systemID) > 253 {
+		return systemID, fmt.Errorf("system-id is greater than what the exporter currently allows: %d vs 253", len(systemID))
 	}
 	return systemID, nil
 }


### PR DESCRIPTION
Currently the system-id limit is set to 36 bytes which corresponds to
the length of a serialized UUID. However, the system-id limit in the
vswitch schema isn't limited by that and allows for arbitrary
identifiers that distinguish different OVS instances:

https://github.com/openvswitch/ovs/blob/ff55e8f3858ae153ef1996df3d52938f3df6d950/vswitchd/vswitch.ovsschema#L27-L29
https://docs.openvswitch.org/en/latest/ref/ovs-ctl.8/#options

In some cases deployments rely on FQDNs for system IDs which causes
labels set by exporters to be set to "unknown".

In order to avoid a completely arbitrary length for this exporter, a
limit of 253 bytes (max domain name length per RFC 1035) is introduced
by this change instead of a hard-coded length of 36.