### PR TITLE
Handle 2 whitespaces in dpctl/show output

### DIFF
--- a/app_datapath.go
+++ b/app_datapath.go
@@ -214,7 +214,7 @@ func getAppDatapath(db string, sock string, timeout int) ([]*OvsDatapath, error)
 			i := strings.Index(line, ":")
 			dpn = line[:i]
 			dp.Name = dpn
-		case 1:
+		case 1, 2:
 			if dp == nil {
 				continue
 			}


### PR DESCRIPTION
It appears to be that in the current versions of OVS there are 2
whitespaces present on lines following the datapath line.

Not handling this case results in having errors like

'dpctl/show' command return for vswitchd-service failed output analysis
source="ovs_exporter.go:627"

and the lack of OVS datapath metrics present at the metrics endpoint.