### PR TITLE
fix: Remove hard code socket control path

### DIFF
--- a/ovs.go
+++ b/ovs.go
@@ -69,14 +69,14 @@ func NewOvsClient() *OvsClient {
 	cli.Service.Vswitchd.Process.Group = "openvswitch"
 	cli.Service.Vswitchd.File.Log.Path = "/var/log/openvswitch/ovs-vswitchd.log"
 	cli.Service.Vswitchd.File.Pid.Path = "/var/run/openvswitch/ovs-vswitchd.pid"
-	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("/var/run/openvswitch/ovs-vswitchd.%d.ctl", cli.Service.Vswitchd.Process.ID)
+	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("%s/ovs-vswitchd.%d.ctl", cli.System.RunDir, cli.Service.Vswitchd.Process.ID)
 
 	cli.Service.OvnController.Process.ID = 0
 	cli.Service.OvnController.Process.User = "openvswitch"
 	cli.Service.OvnController.Process.Group = "openvswitch"
 	cli.Service.OvnController.File.Log.Path = "/var/log/openvswitch/ovn-controller.log"
 	cli.Service.OvnController.File.Pid.Path = "/var/run/openvswitch/ovn-controller.pid"
-	cli.Service.OvnController.Socket.Control = fmt.Sprintf("/var/run/openvswitch/ovn-controller.%d.ctl", cli.Service.OvnController.Process.ID)
+	cli.Service.OvnController.Socket.Control = fmt.Sprintf("%s/ovn-controller.%d.ctl", cli.System.RunDir, cli.Service.OvnController.Process.ID)
 
 	return &cli
 }
@@ -102,7 +102,7 @@ func (cli *OvsClient) Close() {
 }
 
 func (cli *OvsClient) updateRefs() {
-	cli.Database.Vswitch.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovsdb-server.%d.ctl", cli.Database.Vswitch.Process.ID)
-	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovs-vswitchd.%d.ctl", cli.Service.Vswitchd.Process.ID)
-	cli.Service.OvnController.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovn-controller.%d.ctl", cli.Service.OvnController.Process.ID)
+	cli.Database.Vswitch.Socket.Control = fmt.Sprintf("unix:%s/ovsdb-server.%d.ctl", cli.System.RunDir, cli.Database.Vswitch.Process.ID)
+	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("unix:%s/ovs-vswitchd.%d.ctl", cli.System.RunDir, cli.Service.Vswitchd.Process.ID)
+	cli.Service.OvnController.Socket.Control = fmt.Sprintf("unix:%s/ovn-controller.%d.ctl", cli.System.RunDir, cli.Service.OvnController.Process.ID)
 }

--- a/ovs_test.go
+++ b/ovs_test.go
@@ -1,0 +1,30 @@
+package ovsdb
+
+import (
+	"testing"
+)
+
+func TestUpdateRefs(t *testing.T) {
+	client := NewOvsClient()
+
+	client.Database.Vswitch.Process.ID = 200
+	client.Service.Vswitchd.Process.ID = 201
+	client.Service.OvnController.Process.ID = 202
+	client.System.RunDir = "/tmp/random-path"
+
+	client.updateRefs()
+	expectedDatabaseCtrl := "unix:/tmp/random-path/ovsdb-server.200.ctl"
+	if client.Database.Vswitch.Socket.Control != expectedDatabaseCtrl {
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedDatabaseCtrl, client.Database.Vswitch.Socket.Control)
+	}
+
+	expectedVswitchdCtrl := "unix:/tmp/random-path/ovs-vswitchd.201.ctl"
+	if client.Service.Vswitchd.Socket.Control != expectedVswitchdCtrl {
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedVswitchdCtrl, client.Service.Vswitchd.Socket.Control)
+	}
+
+	expectedControllerCtrl := "unix:/tmp/random-path/ovn-controller.202.ctl"
+	if client.Service.OvnController.Socket.Control != expectedControllerCtrl {
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedControllerCtrl, client.Service.Vswitchd.Socket.Control)
+	}
+}


### PR DESCRIPTION
Remove the hard core `/var/run/openvswitch/`
Right now it will be replaced by `Client.System.RunDir`