### PR TITLE
fix: Remove hard code socket control path

### DIFF
--- a/ovn.go
+++ b/ovn.go
@@ -58,7 +58,7 @@ func NewOvnClient() *OvnClient {
 	cli.Database.Vswitch.Schema.Version = "unknown"
 	cli.Database.Vswitch.Name = "Open_vSwitch"
 	cli.Database.Vswitch.Socket.Remote = "unix:/var/run/openvswitch/db.sock"
-	cli.Database.Vswitch.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovsdb-server.%d.ctl", cli.Database.Vswitch.Process.ID)
+	cli.Database.Vswitch.Socket.Control = fmt.Sprintf("unix:%s/ovsdb-server.%d.ctl", cli.System.RunDir, cli.Database.Vswitch.Process.ID)
 	cli.Database.Vswitch.File.Data.Path = "/etc/openvswitch/conf.db"
 	cli.Database.Vswitch.File.Log.Path = "/var/log/openvswitch/ovsdb-server.log"
 	cli.Database.Vswitch.File.Pid.Path = "/var/run/openvswitch/ovsdb-server.pid"
@@ -97,14 +97,14 @@ func NewOvnClient() *OvnClient {
 	cli.Service.Vswitchd.Process.Group = "openvswitch"
 	cli.Service.Vswitchd.File.Log.Path = "/var/log/openvswitch/ovs-vswitchd.log"
 	cli.Service.Vswitchd.File.Pid.Path = "/var/run/openvswitch/ovs-vswitchd.pid"
-	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovs-vswitchd.%d.ctl", cli.Service.Vswitchd.Process.ID)
+	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("unix:%s/ovs-vswitchd.%d.ctl", cli.System.RunDir, cli.Service.Vswitchd.Process.ID)
 
 	cli.Service.Northd.Process.ID = 0
 	cli.Service.Northd.Process.User = "openvswitch"
 	cli.Service.Northd.Process.Group = "openvswitch"
 	cli.Service.Northd.File.Log.Path = "/var/log/openvswitch/ovn-northd.log"
 	cli.Service.Northd.File.Pid.Path = "/run/openvswitch/ovn-northd.pid"
-	cli.Service.Northd.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovn-northd.%d.ctl", cli.Service.Northd.Process.ID)
+	cli.Service.Northd.Socket.Control = fmt.Sprintf("unix:%s/ovn-northd.%d.ctl", cli.System.RunDir, cli.Service.Northd.Process.ID)
 
 	return &cli
 }
@@ -156,7 +156,7 @@ func (cli *OvnClient) Close() {
 }
 
 func (cli *OvnClient) updateRefs() {
-	cli.Database.Vswitch.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovsdb-server.%d.ctl", cli.Database.Vswitch.Process.ID)
-	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovs-vswitchd.%d.ctl", cli.Service.Vswitchd.Process.ID)
-	cli.Service.Northd.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovn-northd.%d.ctl", cli.Service.Northd.Process.ID)
+	cli.Database.Vswitch.Socket.Control = fmt.Sprintf("unix:%s/ovsdb-server.%d.ctl", cli.System.RunDir, cli.Database.Vswitch.Process.ID)
+	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("unix:%s/ovs-vswitchd.%d.ctl", cli.System.RunDir, cli.Service.Vswitchd.Process.ID)
+	cli.Service.Northd.Socket.Control = fmt.Sprintf("unix:%s/ovn-northd.%d.ctl", cli.System.RunDir, cli.Service.Northd.Process.ID)
 }

--- a/ovn_test.go
+++ b/ovn_test.go
@@ -1,0 +1,30 @@
+package ovsdb
+
+import (
+	"testing"
+)
+
+func TestOvnClientUpdateRefs(t *testing.T) {
+	client := NewOvnClient()
+
+	client.Database.Vswitch.Process.ID = 200
+	client.Service.Vswitchd.Process.ID = 201
+	client.Service.Northd.Process.ID = 202
+	client.System.RunDir = "/tmp/random-path"
+
+	client.updateRefs()
+	expectedDatabaseCtrl := "unix:/tmp/random-path/ovsdb-server.200.ctl"
+	if client.Database.Vswitch.Socket.Control != expectedDatabaseCtrl {
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedDatabaseCtrl, client.Database.Vswitch.Socket.Control)
+	}
+
+	expectedVswitchdCtrl := "unix:/tmp/random-path/ovs-vswitchd.201.ctl"
+	if client.Service.Vswitchd.Socket.Control != expectedVswitchdCtrl {
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedVswitchdCtrl, client.Service.Vswitchd.Socket.Control)
+	}
+
+	expectedNorthdCtrl := "unix:/tmp/random-path/ovn-northd.202.ctl"
+	if client.Service.Northd.Socket.Control != expectedNorthdCtrl {
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedNorthdCtrl, client.Service.Vswitchd.Socket.Control)
+	}
+}

--- a/ovs.go
+++ b/ovs.go
@@ -69,14 +69,14 @@ func NewOvsClient() *OvsClient {
 	cli.Service.Vswitchd.Process.Group = "openvswitch"
 	cli.Service.Vswitchd.File.Log.Path = "/var/log/openvswitch/ovs-vswitchd.log"
 	cli.Service.Vswitchd.File.Pid.Path = "/var/run/openvswitch/ovs-vswitchd.pid"
-	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("/var/run/openvswitch/ovs-vswitchd.%d.ctl", cli.Service.Vswitchd.Process.ID)
+	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("%s/ovs-vswitchd.%d.ctl", cli.System.RunDir, cli.Service.Vswitchd.Process.ID)
 
 	cli.Service.OvnController.Process.ID = 0
 	cli.Service.OvnController.Process.User = "openvswitch"
 	cli.Service.OvnController.Process.Group = "openvswitch"
 	cli.Service.OvnController.File.Log.Path = "/var/log/openvswitch/ovn-controller.log"
 	cli.Service.OvnController.File.Pid.Path = "/var/run/openvswitch/ovn-controller.pid"
-	cli.Service.OvnController.Socket.Control = fmt.Sprintf("/var/run/openvswitch/ovn-controller.%d.ctl", cli.Service.OvnController.Process.ID)
+	cli.Service.OvnController.Socket.Control = fmt.Sprintf("%s/ovn-controller.%d.ctl", cli.System.RunDir, cli.Service.OvnController.Process.ID)
 
 	return &cli
 }
@@ -102,7 +102,7 @@ func (cli *OvsClient) Close() {
 }
 
 func (cli *OvsClient) updateRefs() {
-	cli.Database.Vswitch.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovsdb-server.%d.ctl", cli.Database.Vswitch.Process.ID)
-	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovs-vswitchd.%d.ctl", cli.Service.Vswitchd.Process.ID)
-	cli.Service.OvnController.Socket.Control = fmt.Sprintf("unix:/var/run/openvswitch/ovn-controller.%d.ctl", cli.Service.OvnController.Process.ID)
+	cli.Database.Vswitch.Socket.Control = fmt.Sprintf("unix:%s/ovsdb-server.%d.ctl", cli.System.RunDir, cli.Database.Vswitch.Process.ID)
+	cli.Service.Vswitchd.Socket.Control = fmt.Sprintf("unix:%s/ovs-vswitchd.%d.ctl", cli.System.RunDir, cli.Service.Vswitchd.Process.ID)
+	cli.Service.OvnController.Socket.Control = fmt.Sprintf("unix:%s/ovn-controller.%d.ctl", cli.System.RunDir, cli.Service.OvnController.Process.ID)
 }

--- a/ovs_test.go
+++ b/ovs_test.go
@@ -1,0 +1,30 @@
+package ovsdb
+
+import (
+	"testing"
+)
+
+func TestOvsClientUpdateRefs(t *testing.T) {
+	client := NewOvsClient()
+
+	client.Database.Vswitch.Process.ID = 200
+	client.Service.Vswitchd.Process.ID = 201
+	client.Service.OvnController.Process.ID = 202
+	client.System.RunDir = "/tmp/random-path"
+
+	client.updateRefs()
+	expectedDatabaseCtrl := "unix:/tmp/random-path/ovsdb-server.200.ctl"
+	if client.Database.Vswitch.Socket.Control != expectedDatabaseCtrl {
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedDatabaseCtrl, client.Database.Vswitch.Socket.Control)
+	}
+
+	expectedVswitchdCtrl := "unix:/tmp/random-path/ovs-vswitchd.201.ctl"
+	if client.Service.Vswitchd.Socket.Control != expectedVswitchdCtrl {
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedVswitchdCtrl, client.Service.Vswitchd.Socket.Control)
+	}
+
+	expectedControllerCtrl := "unix:/tmp/random-path/ovn-controller.202.ctl"
+	if client.Service.OvnController.Socket.Control != expectedControllerCtrl {
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedControllerCtrl, client.Service.Vswitchd.Socket.Control)
+	}
+}


### PR DESCRIPTION
Remove the hard code `/var/run/openvswitch/`
Right now it will be replaced by `Client.System.RunDir`