### PR TITLE
Remove Vswitch dependency from OvnClient

### DIFF
--- a/app_coverage.go
+++ b/app_coverage.go
@@ -78,8 +78,6 @@ func (cli *OvnClient) GetAppCoverageMetrics(db string) (map[string]map[string]fl
 		return getAppCoverageMetrics(db, cli.Database.Northbound.Socket.Control, cli.Timeout)
 	case "ovsdb-server-southbound":
 		return getAppCoverageMetrics(db, cli.Database.Southbound.Socket.Control, cli.Timeout)
-	case "ovsdb-server":
-		return getAppCoverageMetrics(db, cli.Database.Vswitch.Socket.Control, cli.Timeout)
 	default:
 		return nil, fmt.Errorf("The '%s' database is unsupported for '%s'", db, cmd)
 	}

--- a/app_list_cmd.go
+++ b/app_list_cmd.go
@@ -59,8 +59,6 @@ func (cli *OvnClient) AppListCommands(db string) (map[string]bool, error) {
 		return appListCommands(db, cli.Database.Northbound.Socket.Control, cli.Timeout)
 	case "ovsdb-server-southbound":
 		return appListCommands(db, cli.Database.Southbound.Socket.Control, cli.Timeout)
-	case "ovsdb-server":
-		return appListCommands(db, cli.Database.Vswitch.Socket.Control, cli.Timeout)
 	default:
 		return nil, fmt.Errorf("The '%s' database is unsupported for '%s'", db, cmd)
 	}

--- a/app_memory.go
+++ b/app_memory.go
@@ -69,8 +69,6 @@ func (cli *OvnClient) GetAppMemoryMetrics(db string) (map[string]float64, error)
 		return getAppMemoryMetrics(db, cli.Database.Northbound.Socket.Control, cli.Timeout)
 	case "ovsdb-server-southbound":
 		return getAppMemoryMetrics(db, cli.Database.Southbound.Socket.Control, cli.Timeout)
-	case "ovsdb-server":
-		return getAppMemoryMetrics(db, cli.Database.Vswitch.Socket.Control, cli.Timeout)
 	default:
 		return nil, fmt.Errorf("The '%s' database is unsupported for '%s'", db, cmd)
 	}

--- a/log.go
+++ b/log.go
@@ -96,13 +96,6 @@ func readLogFile(f OvsDataFile) (map[string]map[string]uint64, int64, error) {
 // GetLogFileEventStats TODO
 func (cli *OvnClient) GetLogFileEventStats(name string) (map[string]map[string]uint64, error) {
 	switch name {
-	case "ovsdb-server":
-		stats, offset, err := readLogFile(cli.Database.Vswitch.File.Log)
-		if err != nil {
-			return stats, err
-		}
-		cli.Database.Vswitch.File.Log.Reader.Offset = offset
-		return stats, nil
 	case "ovsdb-server-northbound":
 		stats, offset, err := readLogFile(cli.Database.Northbound.File.Log)
 		if err != nil {
@@ -123,13 +116,6 @@ func (cli *OvnClient) GetLogFileEventStats(name string) (map[string]map[string]u
 			return stats, err
 		}
 		cli.Service.Northd.File.Log.Reader.Offset = offset
-		return stats, nil
-	case "ovs-vswitchd":
-		stats, offset, err := readLogFile(cli.Service.Vswitchd.File.Log)
-		if err != nil {
-			return stats, err
-		}
-		cli.Service.Vswitchd.File.Log.Reader.Offset = offset
 		return stats, nil
 	}
 	return nil, fmt.Errorf("The '%s' component is unsupported", name)
@@ -161,13 +147,6 @@ func (cli *OvnClient) GetLogFileInfo(name string) (OvsDataFile, error) {
 	var i os.FileInfo
 	var err error
 	switch name {
-	case "ovsdb-server":
-		i, err = os.Stat(cli.Database.Vswitch.File.Log.Path)
-		if err == nil {
-			cli.Database.Vswitch.File.Log.Info = i
-			cli.Database.Vswitch.File.Log.Component = name
-			return cli.Database.Vswitch.File.Log, nil
-		}
 	case "ovsdb-server-northbound":
 		i, err = os.Stat(cli.Database.Northbound.File.Log.Path)
 		if err == nil {
@@ -188,13 +167,6 @@ func (cli *OvnClient) GetLogFileInfo(name string) (OvsDataFile, error) {
 			cli.Service.Northd.File.Log.Info = i
 			cli.Service.Northd.File.Log.Component = name
 			return cli.Service.Northd.File.Log, nil
-		}
-	case "ovs-vswitchd":
-		i, err = os.Stat(cli.Service.Vswitchd.File.Log.Path)
-		if err == nil {
-			cli.Service.Vswitchd.File.Log.Info = i
-			cli.Service.Vswitchd.File.Log.Component = name
-			return cli.Service.Vswitchd.File.Log, nil
 		}
 	default:
 		return OvsDataFile{}, fmt.Errorf("The '%s' component is unsupported", name)

--- a/ovn_test.go
+++ b/ovn_test.go
@@ -21,24 +21,13 @@ import (
 func TestOvnClientUpdateRefs(t *testing.T) {
 	client := NewOvnClient()
 
-	client.Database.Vswitch.Process.ID = 200
-	client.Service.Vswitchd.Process.ID = 201
 	client.Service.Northd.Process.ID = 202
-	client.System.RunDir = "/tmp/random-path"
+	client.Service.Northd.File.Pid.Path = "/tmp/random-path/ovn-northd.pid"
 
 	client.updateRefs()
-	expectedDatabaseCtrl := "unix:/tmp/random-path/ovsdb-server.200.ctl"
-	if client.Database.Vswitch.Socket.Control != expectedDatabaseCtrl {
-		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedDatabaseCtrl, client.Database.Vswitch.Socket.Control)
-	}
-
-	expectedVswitchdCtrl := "unix:/tmp/random-path/ovs-vswitchd.201.ctl"
-	if client.Service.Vswitchd.Socket.Control != expectedVswitchdCtrl {
-		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedVswitchdCtrl, client.Service.Vswitchd.Socket.Control)
-	}
 
 	expectedNorthdCtrl := "unix:/tmp/random-path/ovn-northd.202.ctl"
 	if client.Service.Northd.Socket.Control != expectedNorthdCtrl {
-		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedNorthdCtrl, client.Service.Vswitchd.Socket.Control)
+		t.Errorf("UpdateRefs fail. Expected: %s Ctrl: %s", expectedNorthdCtrl, client.Service.Northd.Socket.Control)
 	}
 }

--- a/process.go
+++ b/process.go
@@ -109,8 +109,6 @@ func (cli *OvnClient) GetProcessInfo(name string) (OvsProcess, error) {
 	var p OvsProcess
 	var err error
 	switch name {
-	case "ovsdb-server":
-		p, err = getProcessInfoFromFile(cli.Database.Vswitch.File.Pid.Path)
 	case "ovsdb-server-southbound":
 		p, err = getProcessInfoFromFile(cli.Database.Southbound.File.Pid.Path)
 	case "ovsdb-server-southbound-monitoring":
@@ -123,8 +121,6 @@ func (cli *OvnClient) GetProcessInfo(name string) (OvsProcess, error) {
 		p, err = getProcessInfoFromFile(cli.Service.Northd.File.Pid.Path)
 	case "ovn-northd-monitoring":
 		p, err = getProcessInfo(cli.Service.Northd.Process.Parent.ID)
-	case "ovs-vswitchd":
-		p, err = getProcessInfoFromFile(cli.Service.Vswitchd.File.Pid.Path)
 	default:
 		return OvsProcess{}, fmt.Errorf("The '%s' component is unsupported", name)
 	}
@@ -132,8 +128,6 @@ func (cli *OvnClient) GetProcessInfo(name string) (OvsProcess, error) {
 		return OvsProcess{}, err
 	}
 	switch name {
-	case "ovsdb-server":
-		cli.Database.Vswitch.Process = p
 	case "ovsdb-server-southbound":
 		cli.Database.Southbound.Process = p
 	case "ovsdb-server-southbound-monitoring":
@@ -146,8 +140,6 @@ func (cli *OvnClient) GetProcessInfo(name string) (OvsProcess, error) {
 		cli.Service.Northd.Process = p
 	case "ovn-northd-monitoring":
 		cli.Service.Northd.Process.Parent.ID = p.ID
-	case "ovs-vswitchd":
-		cli.Service.Vswitchd.Process = p
 	}
 	return p, nil
 }


### PR DESCRIPTION
# Remove Vswitch dependency from OvnClient

## Summary

Remove Open_vSwitch (Vswitch) dependency from OvnClient, making it a pure OVN-only client.

In OpenStack OVN environments, Controller nodes (NB+SB) and Compute nodes (OVS) are deployed separately. The previous OvnClient bundled all three databases and attempted to connect to all of them via `Connect()`, causing unnecessary connection failures on Controller nodes where no Vswitch socket exists.

After this change:
- OvnClient: OVN Northbound + Southbound only
- OvsClient: Open_vSwitch only (unchanged)

## Changes

**OvnClient struct (`ovn.go`)**
- Remove `Database.Vswitch`, `Service.Vswitchd`, `System` fields
- Remove Vswitch connection logic from `Connect()`/`Close()`
- Derive Northd control socket path from `filepath.Dir(PidPath)` instead of `System.RunDir`

**Remove Vswitch cases from OvnClient methods**
- `app_coverage.go`, `app_list_cmd.go`, `app_memory.go`: remove `"ovsdb-server"` case
- `process.go`, `log.go`: remove `"ovsdb-server"` and `"ovs-vswitchd"` cases

**Remove OvnClient-specific methods (`system.go`)**
- `OvnClient.GetSystemID()`, `OvnClient.GetSystemInfo()` — identical methods remain on OvsClient

**Tests (`ovn_test.go`)**
- Remove Vswitch/Vswitchd test cases, update Northd test

## Breaking Changes

| Before | After | Migration |
|--------|-------|-----------|
| `ovnClient.Database.Vswitch` | Removed | Use `ovsClient.Database.Vswitch` |
| `ovnClient.GetSystemInfo()` | Removed | Use `ovsClient.GetSystemInfo()` |
| `ovnClient.GetSystemID()` | Removed | Use `ovsClient.GetSystemID()` |
| `ovnClient.GetProcessInfo("ovsdb-server")` | Returns unsupported error | Use `ovsClient.GetProcessInfo("ovsdb-server")` |

## Test plan

- [x] `go build ./...` compiles successfully
- [x] Existing OvsClient tests unaffected
